### PR TITLE
Add optional second parameter to injectUniqueness.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ and the client.
 
 ## API
 
-### enableUniqueIds(component)
+### enableUniqueIds(component, [instanceId])
 
 This should be called from the constructor of the component that needs unique IDs,
-passing `this` as the parameter. After calling this you can use `nextUniqueId`, `lastUniqueId` and `getUniqueId` by invoking them on `this`.
+passing `this` as the first parameter. After calling this you can use `nextUniqueId`, `lastUniqueId` and `getUniqueId`
+by invoking them on `this`.
 
 This call either adds a `componentWillUpdate` handler to the current component,
 or wraps the existing one. The package uses `componentWillUpdate` to reset the
@@ -103,6 +104,15 @@ ID counter every time the component re-renders.
             // ...
         }
     }
+
+The second optional `instanceId` parameter specifies a string to use for _all_ instances of this component when
+constructing unique IDs, as opposed to using a unique string for each instance. While this essentially defeats the
+purpose of this module when there are multiple instances of your component on the page, it's useful for snapshot-based
+unit testing, e.g. [Storyshots](https://github.com/storybooks/storybook/tree/master/addons/storyshots), where the
+indeterminate nature of test execution order might generaate different unique IDs on each test run. In this case, you'll
+likely want want to only use it when you're actually running the unit tests:
+
+    enableUniqueIds(this, (process.env.NODE_ENV === 'test') ? props.name : undefined)
 
 ### Component.nextUniqueId()
 

--- a/index.js
+++ b/index.js
@@ -11,11 +11,20 @@ function resetUniqueIds() {
 
 function injectUniqueness(component) {
 
+    var instanceId;
+    if (arguments.length > 1) {
+        instanceId = arguments[1];
+        if (typeof instanceId !== 'string') {
+            console.log('Warning: Expected string as second argument passed to `injectUniqueness`')
+            instanceId = '' + instanceId
+        }
+    }
+
     // Store all state in the closure for the member functions
     var _willUpdate = component.componentWillUpdate
     var _htmlIds = {}
     var _uniqueIdCounter = 0
-    var _uniqueInstance = ++_globallyUniqueIdCounter
+    var _uniqueInstance = instanceId || ++_globallyUniqueIdCounter
 
     // Inject the following functions into the component
     component.componentWillUpdate = function(nextProps, nextState) {


### PR DESCRIPTION
**Problem**: When testing components that use `injectUniqueness` using a snapshot-based test framework, like [Storyshots](https://github.com/storybooks/storybook/tree/master/addons/storyshots), I was finding that the snapshots were changing from execution to execution, making the tests unstable. Here's what was happening:

* A component being tested, e.g. a custom form component, used multiple instances of a component, e.g. a custom text field, which used `injectUniqueness`.
* The component was one of several components (also with `injectUniqueness`) being tested.
* The oder in which the tests ran was indeterminate, because of Jest's parallel test execution. Therefore, the custom form test might be run fifth or sixth, for example.
* Depending on the order of execution, the internal `_uniqueInstance` variable was being set to a different value, e.g. `5` if it was the fifth test run or `6` if it was the sixth. (This is a bit of an oversimplification, since there were multiple instances of the component in each test. The actual values were probably more like `15` vs `21` or something, but you get the idea.)

**Solution**: Allow the user to specify a value to be used for `_uniqueInstance` by specifying an optional second argument to `injectUniqueness`. This will essentially break uniqueness in this scenario, but allows for the unit test snapshot to be consistent and therefore pass every time, regardless of test execution order. The `README` has been updated with an example that will only send this second parameter if we're running the unit tests, which is probably what most people will want.

In my case, since each text field component was passed a unique `name`, I simply used that as the second parameter to `injectUniqueness`, preserving uniqueness as well as allowing the unit tests to pass.